### PR TITLE
Change local address handling to be more accurate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 language: go
 go:
-  - 1.7.x
-  - 1.8.x
+  - 1.10.x
+  - 1.11.x
+  - 1.12.x
+  - 1.13.x
   - tip
 matrix:
   allow_failures:
@@ -20,4 +22,4 @@ deploy:
   on:
     repo: theag3nt/httpecho
     tags: true
-    condition: $TRAVIS_GO_VERSION =~ ^1\.8
+    condition: $TRAVIS_GO_VERSION =~ ^1\.13

--- a/main.go
+++ b/main.go
@@ -79,7 +79,8 @@ func logHandler(log logger, h http.Handler) http.Handler {
 		if err != nil {
 			remote = r.RemoteAddr
 		}
-		local := r.Host
+		localaddr, _ := r.Context().Value(http.LocalAddrContextKey).(net.Addr)
+		local := localaddr.String()
 
 		log.Printf("%s request from %s on %s\n", method, remote, local)
 

--- a/main_test.go
+++ b/main_test.go
@@ -205,10 +205,8 @@ func TestLogHandler(t *testing.T) {
 			// Prepare context to mimic behaviour of the real server
 			ctx := context.WithValue(context.Background(), http.LocalAddrContextKey, newAddr(tt.local))
 			// Prepare request
-			req, err := http.NewRequestWithContext(ctx, tt.method, "/", nil)
-			if err != nil {
-				t.Fatal(err)
-			}
+			req := httptest.NewRequest(tt.method, "/", nil)
+			req = req.WithContext(ctx)
 			if tt.host == "" {
 				req.Host = tt.local
 			} else {

--- a/main_test.go
+++ b/main_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -37,6 +39,22 @@ func (l *bufferLogger) Println(args ...interface{}) {
 
 func (l *bufferLogger) String() string {
 	return l.b.String()
+}
+
+type addr struct {
+	value string
+}
+
+func newAddr(value string) net.Addr {
+	return addr{value}
+}
+
+func (a addr) String() string {
+	return a.value
+}
+
+func (a addr) Network() string {
+	return "tcp"
 }
 
 func TestValidateArgs(t *testing.T) {
@@ -166,10 +184,11 @@ func TestLogHandler(t *testing.T) {
 		method string
 		remote string
 		local  string
+		host   string
 	}{
-		{"Get", "GET", "127.0.0.1", "127.0.0.1:1234"},
-		{"Post", "POST", "192.168.0.2", "192.168.0.1:1234"},
-		{"Head", "HEAD", "127.0.0.1", "localhost:1234"},
+		{"LoopbackHost", "GET", "127.0.0.1", "127.0.0.1:1234", ""},
+		{"PrivateHost", "POST", "192.168.0.2", "192.168.0.1:1234", ""},
+		{"DomainHost", "HEAD", "127.0.0.1", "127.0.0.1:1234", "localhost:1234"},
 	}
 
 	// Prepare expected results
@@ -183,12 +202,18 @@ func TestLogHandler(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			wantOutput := fmt.Sprintf("%s request from %s on %s\n", tt.method, tt.remote, tt.local)
 
+			// Prepare context to mimic behaviour of the real server
+			ctx := context.WithValue(context.Background(), http.LocalAddrContextKey, newAddr(tt.local))
 			// Prepare request
-			req, err := http.NewRequest(tt.method, "/", nil)
+			req, err := http.NewRequestWithContext(ctx, tt.method, "/", nil)
 			if err != nil {
 				t.Fatal(err)
 			}
-			req.Host = tt.local
+			if tt.host == "" {
+				req.Host = tt.local
+			} else {
+				req.Host = tt.host
+			}
 			req.RemoteAddr = tt.remote
 
 			// Send request to handler


### PR DESCRIPTION
Previously the displayed local address was taken from the requests' Host header, which is of course not very accurate if the server is targeted by domain name. 

Now the value is from a much earlier point in the connection handling process (basically as the interface reports it) thanks to [`LocalAddrContextKey`](https://golang.org/pkg/net/http/#LocalAddrContextKey) (available from Go 1.9).

To make sure that this feature is available in every build the Go versions tested by TravisCI are also updated.